### PR TITLE
Fixed resizing of Operations dialog

### DIFF
--- a/ActionPopupPanel.gd
+++ b/ActionPopupPanel.gd
@@ -209,6 +209,8 @@ func _select_group_button(group):
 		sketch_btn.pressed = true
 		_on_SketchButton_toggled(sketch_btn)
 
+	_on_VBoxContainer_resized()
+
 
 """
 Called when the Ok button is pressed so that the GUI can collect the changed context.
@@ -284,6 +286,14 @@ Called whenever the contents of the main VBoxContainer require a size change.
 func _on_VBoxContainer_resized():
 	# Make sure the panel is the correct size to contain all controls
 	rect_size = Vector2($VBoxContainer.rect_size[0] + 7, $VBoxContainer.rect_size[1] + 7)
+
+	# Work-around to force the size changes to take effect
+	if visible == true:
+		hide()
+		show()
+	else:
+		show()
+		hide()
 
 
 """

--- a/GUI.tscn
+++ b/GUI.tscn
@@ -484,6 +484,8 @@ margin_left = 4.0
 margin_top = 4.0
 margin_right = 66.0
 margin_bottom = 112.0
+size_flags_horizontal = 5
+size_flags_vertical = 5
 
 [node name="ActionGroupsVBoxContainer" type="VBoxContainer" parent="ActionPopupPanel/VBoxContainer"]
 margin_right = 208.0


### PR DESCRIPTION
I found a work-around in the Godot forums where the dev would toggle visibility to force the containers to trigger a resize properly. The problem I was having was that the containers wouldn't resize themselves unless I started dragging the window by the title bar.